### PR TITLE
feat: github-action 타겟 브랜치 변경

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,7 +2,7 @@ name: Deploy to Self-Hosted Runner
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ dev, develop ]
 #   workflow_dispatch:
 #     inputs:
 #       environment:

--- a/README.md
+++ b/README.md
@@ -204,6 +204,3 @@ OpenWebUI에 접속해보면 다음과 같이 추가되어있음을 확인할 �
 
 ## License
 This project is licensed under the [MIT License](https://opensource.org/licenses/MIT).
-
-
-test


### PR DESCRIPTION
- README.md 파일의 라이센스 섹션 공백 제거 
- 배포 워크플로우에서 적용되는 브랜치를 dev 및 develp으로 변경

close #9 