### PR TITLE
fix: API 응답의 'None' 문자열 처리 및 린트 오류 해결

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,7 +84,7 @@ def main(
     # graph_builder.add_node(HantooFinancialAnalyzerNode())
 
     # 미국 주식 분석 에이전트 노드 추가 (Alpha Vantage API 사용)
-    # graph_builder.add_node(USFinancialAnalyzerNode())
+    graph_builder.add_node(USFinancialAnalyzerNode())
 
     vector_store = Container.vector_store_recap()
     graph_builder.add_node(WeeklyReporterNode(vector_store))

--- a/src/graph/nodes/__init__.py
+++ b/src/graph/nodes/__init__.py
@@ -11,8 +11,6 @@ from src.graph.nodes.google_searcher import GoogleSearcherNode
 from src.graph.nodes.hantoo_financial import HantooFinancialAnalyzerNode
 from src.graph.nodes.us_financial import USFinancialAnalyzerNode
 from src.graph.nodes.weekly_reporter import WeeklyReporterNode
-from src.graph.nodes.hantoo_financial import HantooFinancialAnalyzerNode
-from src.graph.nodes.us_financial import USFinancialAnalyzerNode
 
 __all__ = [
     "Node",
@@ -31,8 +29,4 @@ __all__ = [
     "USFinancialAnalyzerNode",
     # Weekly Reporter
     "WeeklyReporterNode",
-    # Financial Analyzers
-    "HantooFinancialAnalyzerNode",
-    "USFinancialAnalyzerNode",
 ]
-

--- a/src/graph/nodes/us_financial.py
+++ b/src/graph/nodes/us_financial.py
@@ -2,6 +2,11 @@ from langgraph.prebuilt import create_react_agent
 from langgraph.types import Command
 from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
+import logging
+import datetime
+import os
+from langsmith import Client
+from langsmith.run_helpers import traceable as trace_run
 
 from src.graph.nodes.base import Node
 from src.models.do import RawResponse
@@ -23,65 +28,178 @@ class USFinancialAnalyzerNode(Node):
         self.agent = None
         self.tools = [USFinancialStatementTool()]
 
+        # Configure logging
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.setLevel(logging.DEBUG)
+
+        # LangSmith 설정
+        try:
+            # LangSmith API 키 설정 확인
+            if "LANGSMITH_API_KEY" not in os.environ:
+                self.logger.warning("LANGSMITH_API_KEY 환경 변수가 설정되지 않았습니다. LangSmith 추적이 비활성화됩니다.")
+                self.langsmith_enabled = False
+            else:
+                # LangSmith 클라이언트 초기화
+                self.client = Client()
+                self.langsmith_enabled = True
+                self.logger.info("LangSmith 클라이언트 초기화 성공")
+        except Exception as e:
+            self.logger.warning(f"LangSmith 클라이언트 초기화 실패: {str(e)}")
+            self.langsmith_enabled = False
+
+    def _get_current_time(self) -> str:
+        """현재 시간을 ISO 형식 문자열로 반환합니다."""
+        return datetime.datetime.utcnow().isoformat()
+
+    # LangSmith 추적 데코레이터 적용
+    @trace_run(name="us_financial_analyzer_run")
     def _run(self, state: dict) -> Command:
-        if self.agent is None:
-            assert state["llm"] is not None, "The State model should include llm"
-            llm = state["llm"]
+        start_time = self._get_current_time()
+        self.logger.info(f"[{start_time}] 실행 시작: _run 메소드")
 
-            # LLM 참조를 도구의 속성에 추가
-            self.tools[0].llm = llm
+        try:
+            # Initialize agent if needed
+            if self.agent is None:
+                assert state["llm"] is not None, "The State model should include llm"
+                llm = state["llm"]
 
-            self.agent = create_react_agent(
-                llm,
-                self.tools,
-                prompt=self.system_prompt,
+                # Log LLM initialization
+                self.logger.info(f"에이전트 초기화 중: LLM 타입 = {type(llm).__name__}")
+
+                # LLM 참조를 도구의 속성에 추가
+                self.tools[0].llm = llm
+
+                self.logger.debug("ReAct 에이전트 생성 중 (도구 및 시스템 프롬프트 설정)")
+                self.agent = create_react_agent(
+                    llm,
+                    self.tools,
+                    prompt=self.system_prompt,
+                )
+                self.logger.info("에이전트 초기화 완료")
+
+            # 사용자 메시지 추출
+            user_message = state["messages"][-1].content
+            safe_message = user_message[:100] + "..." if len(user_message) > 100 else user_message
+            self.logger.info(f"사용자 쿼리 처리 중: '{safe_message}'")
+
+            # Extract ticker symbol
+            self.logger.debug("티커 심볼 추출 시도 중")
+            try:
+                extracted_ticker = self.tools[0]._extract_ticker(user_message)
+
+                ticker_extraction_success = True
+                self.logger.info(f"티커 추출 결과: {extracted_ticker}")
+                self.logger.info(f"티커 추출 성공 여부: {ticker_extraction_success}")
+            except Exception as e:
+
+                ticker_extraction_success = False
+                extracted_ticker = None
+                error_msg = f"티커 추출 실패: {str(e)}"
+                self.logger.error(error_msg)
+                self.logger.error(f"티커 추출 성공 여부: {ticker_extraction_success}")
+
+            # Execute agent
+            self.logger.debug("금융 분석 에이전트 실행 중")
+            agent_start_time = self._get_current_time()
+
+            try:
+                # Execute agent
+                result = self.agent.invoke(state)
+
+                # Get analysis content
+                analysis_text = result["messages"][-1].content
+
+                # Truncate log output to prevent overwhelming logs
+                log_analysis_preview = analysis_text[:200] + "..." if len(analysis_text) > 200 else analysis_text
+                agent_end_time = self._get_current_time()
+                self.logger.info(f"금융 분석 완료, 결과 미리보기: \n{log_analysis_preview}")
+                self.logger.debug(f"에이전트 실행 시간: {agent_start_time} ~ {agent_end_time}")
+
+            except Exception as e:
+                error_msg = f"에이전트 실행 실패: {str(e)}"
+                self.logger.error(error_msg)
+                # Re-raise to be handled by the graph
+                raise
+
+            # Use extracted ticker or set as unknown
+            ticker = extracted_ticker if extracted_ticker else "unknown"
+            self.logger.info(f"최종 사용 티커: {ticker}")
+
+            # Create command for next step
+            command = Command(
+                update={
+                    "messages": [
+                        HumanMessage(
+                            content=analysis_text,
+                            name="us_financial_analyzer",
+                        )
+                    ],
+                    # Store analysis results in structured format
+                    "financial_analysis": {
+                        "ticker": ticker,
+                        "market": "US",
+                        "analysis_text": analysis_text,
+                    },
+                },
+                goto="supervisor",
             )
 
-        # 사용자 메시지 추출
-        user_message = state["messages"][-1].content
+            end_time = self._get_current_time()
+            self.logger.info(f"[{end_time}] _run 메소드 실행 완료")
+            return command
 
-        # 도구에서 티커 심볼 추출 (LLM 사용)
-        extracted_ticker = self.tools[0]._extract_ticker(user_message)
+        except Exception as e:
+            self.logger.error(f"_run 메소드에서 오류 발생: {str(e)}", exc_info=True)
+            # Re-raise for proper error handling in the graph
+            raise
 
-        self.logger.info(f"[DEBUG] Ticker extracted: {extracted_ticker}")
-
-        # 에이전트 실행
-        result = self.agent.invoke(state)
-
-        analysis_text = result["messages"][-1].content
-        self.logger.info(f"US Financial analysis result: \n{analysis_text}")
-
-        # 추출된 티커가 있으면 그대로 사용, 없으면 unknown
-        ticker = extracted_ticker if extracted_ticker else "unknown"
-
-        return Command(
-            update={
-                "messages": [
-                    HumanMessage(
-                        content=analysis_text,
-                        name="us_financial_analyzer",
-                    )
-                ],
-                # Store analysis results in structured format
-                "financial_analysis": {
-                    "ticker": ticker,
-                    "market": "US",
-                    "analysis_text": analysis_text,
-                },
-            },
-            goto="supervisor",
-        )
-
+    # LangSmith 추적 데코레이터 적용
+    @trace_run(name="us_financial_analyzer_invoke")
     def _invoke(self, query: str) -> RawResponse:
-        agent = self.agent or create_react_agent(
-            ChatOpenAI(model=self.DEFAULT_LLM_MODEL),
-            self.tools,
-            prompt=self.system_prompt,
-        )
+        start_time = self._get_current_time()
+        self.logger.info(f"[{start_time}] 직접 호출 시작: _invoke 메소드")
 
-        # _invoke 호출 시에도 LLM 설정
-        if not hasattr(self.tools[0], "llm") or self.tools[0].llm is None:
-            self.tools[0].llm = ChatOpenAI(model=self.DEFAULT_LLM_MODEL)
+        try:
+            safe_query = query[:100] + "..." if len(query) > 100 else query
+            self.logger.info(f"쿼리로 직접 호출: '{safe_query}'")
 
-        result = agent.invoke({"messages": [("human", query)]})
-        return RawResponse(answer=result["messages"][-1].content)
+            # Initialize agent if needed
+            agent = self.agent
+            if agent is None:
+                self.logger.debug("직접 호출을 위한 새 에이전트 생성 중")
+                default_llm = ChatOpenAI(model=self.DEFAULT_LLM_MODEL)
+
+                agent = create_react_agent(
+                    default_llm,
+                    self.tools,
+                    prompt=self.system_prompt,
+                )
+
+            # Set LLM in tool if needed
+            if not hasattr(self.tools[0], "llm") or self.tools[0].llm is None:
+                default_llm = ChatOpenAI(model=self.DEFAULT_LLM_MODEL)
+                self.tools[0].llm = default_llm
+                self.logger.debug(f"금융 도구에 기본 LLM 설정: {self.DEFAULT_LLM_MODEL}")
+
+            # Execute agent
+            self.logger.debug("직접 쿼리로 에이전트 실행 중")
+            agent_start_time = self._get_current_time()
+
+            result = agent.invoke({"messages": [("human", query)]})
+            response_content = result["messages"][-1].content
+
+            agent_end_time = self._get_current_time()
+            self.logger.info(f"직접 호출 완료: {agent_start_time} ~ {agent_end_time}, 응답 길이: {len(response_content)}")
+
+            response = RawResponse(answer=response_content)
+
+            end_time = self._get_current_time()
+            self.logger.info(f"[{end_time}] _invoke 메소드 실행 완료")
+            return response
+
+        except Exception as e:
+            error_msg = f"_invoke 메소드에서 오류 발생: {str(e)}"
+            self.logger.error(error_msg, exc_info=True)
+
+            # Return error response
+            return RawResponse(answer=f"금융 분석 중 오류가 발생했습니다: {str(e)}")

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -11,12 +11,6 @@ from src.tools.us_stock.tool import (
     USFinancialStatementTool,
 )
 from src.tools.google_searcher.tool import GoogleSearchResults, GoogleSearch
-from src.tools.hantoo_stock.tool import (
-    HantooFinancialStatementTool,
-)
-from src.tools.us_stock.tool import (
-    USFinancialStatementTool,
-)
 
 __all__ = [
     "NaverSearchResults",

--- a/src/tools/hantoo_stock/hantoo_stock.py
+++ b/src/tools/hantoo_stock/hantoo_stock.py
@@ -281,7 +281,6 @@ class HantooStockAPIWrapper(BaseModel):
                 recent_net_income = float(recent.get("thtr_ntin", 0))
 
                 previous_sales = float(previous.get("sale_account", 0))
-                previous_op_profit = float(previous.get("bsop_prti", 0))
                 previous_net_income = float(previous.get("thtr_ntin", 0))
 
                 # Add basic metrics

--- a/tests/hantoo_stock/hantoo_financial_test.py
+++ b/tests/hantoo_stock/hantoo_financial_test.py
@@ -1,17 +1,15 @@
+import sys
 import unittest
 from unittest.mock import patch, MagicMock
 from dotenv import load_dotenv
+from src.graph.nodes.hantoo_financial import HantooFinancialAnalyzerNode
+from langchain_core.messages import HumanMessage, AIMessage
 
 # .env 파일 로드
 load_dotenv()
 
 # 경로 설정
-import sys
-
 sys.path.append("..")  # 상위 디렉토리 추가
-
-from src.graph.nodes.hantoo_financial import HantooFinancialAnalyzerNode
-from langchain_core.messages import HumanMessage, AIMessage
 
 
 class TestHantooFinancialNode(unittest.TestCase):

--- a/tests/hantoo_stock/hantoo_stock_test.py
+++ b/tests/hantoo_stock/hantoo_stock_test.py
@@ -1,17 +1,15 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch, MagicMock
-import os
 from dotenv import load_dotenv
+from src.tools.hantoo_stock.hantoo_stock import HantooStockAPIWrapper
 
 # .env 파일 로드
 load_dotenv()
 
 # 경로 설정
-import sys
-
 sys.path.append("..")  # 상위 디렉토리 추가
-
-from src.tools.hantoo_stock.hantoo_stock import HantooStockAPIWrapper
 
 
 class TestHantooStockAPI(unittest.TestCase):
@@ -21,7 +19,7 @@ class TestHantooStockAPI(unittest.TestCase):
         """테스트 설정"""
         # API 키가 환경변수에 설정되어 있는지 확인
         self.api_key_exists = (
-            "HANTOO_APP_KEY" in os.environ and "HANTOO_APP_SECRET" in os.environ
+                "HANTOO_APP_KEY" in os.environ and "HANTOO_APP_SECRET" in os.environ
         )
 
         if self.api_key_exists:

--- a/tests/hantoo_stock/hantoo_stock_tool_test.py
+++ b/tests/hantoo_stock/hantoo_stock_tool_test.py
@@ -1,17 +1,15 @@
+import sys
 import unittest
 from unittest.mock import patch
 from dotenv import load_dotenv
+from src.tools.hantoo_stock.tool import HantooFinancialStatementTool
+from src.tools.hantoo_stock.hantoo_stock import HantooStockAPIWrapper
 
 # .env 파일 로드
 load_dotenv()
 
 # 경로 설정
-import sys
-
 sys.path.append("..")  # 상위 디렉토리 추가
-
-from src.tools.hantoo_stock.tool import HantooFinancialStatementTool
-from src.tools.hantoo_stock.hantoo_stock import HantooStockAPIWrapper
 
 
 class TestHantooStockTool(unittest.TestCase):

--- a/tests/us_stock/alpha_vantage_test.py
+++ b/tests/us_stock/alpha_vantage_test.py
@@ -1,17 +1,15 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch, MagicMock
-import os
 from dotenv import load_dotenv
+from src.tools.us_stock.alpha_vantage import AlphaVantageAPIWrapper
 
 # .env 파일 로드
 load_dotenv()
 
 # 경로 설정
-import sys
-
 sys.path.append("..")  # 상위 디렉토리 추가
-
-from src.tools.us_stock.alpha_vantage import AlphaVantageAPIWrapper
 
 
 class TestAlphaVantageAPI(unittest.TestCase):
@@ -179,7 +177,7 @@ class TestAlphaVantageAPI(unittest.TestCase):
     )
     @patch("src.tools.us_stock.alpha_vantage.AlphaVantageAPIWrapper.get_cash_flow")
     def test_analyze_financial_statements(
-        self, mock_cash_flow, mock_income, mock_balance, mock_overview
+            self, mock_cash_flow, mock_income, mock_balance, mock_overview
     ):
         """재무제표 분석 테스트"""
         # 각 메소드에 대한 목 응답 설정

--- a/tests/us_stock/us_financial_test.py
+++ b/tests/us_stock/us_financial_test.py
@@ -1,18 +1,16 @@
+import sys
 import unittest
 from unittest.mock import patch, MagicMock
 from dotenv import load_dotenv
+from src.graph.nodes.us_financial import USFinancialAnalyzerNode
+from src.tools.us_stock.tool import USFinancialStatementTool
+from langchain_core.messages import HumanMessage, AIMessage
 
 # Load .env file
 load_dotenv()
 
 # Set path
-import sys
-
 sys.path.append("..")  # Add parent directory
-
-from src.graph.nodes.us_financial import USFinancialAnalyzerNode
-from src.tools.us_stock.tool import USFinancialStatementTool
-from langchain_core.messages import HumanMessage, AIMessage
 
 
 class TestUSFinancialNode(unittest.TestCase):
@@ -185,7 +183,7 @@ class TestUSFinancialNode(unittest.TestCase):
 
         # We need to mock the tool's _extract_ticker to handle Korean text
         with patch.object(
-            USFinancialStatementTool, "_extract_ticker", return_value="AAPL"
+                USFinancialStatementTool, "_extract_ticker", return_value="AAPL"
         ):
             # Execute node
             self.node.agent = mock_agent

--- a/tests/us_stock/us_financial_tool_test.py
+++ b/tests/us_stock/us_financial_tool_test.py
@@ -1,17 +1,15 @@
+import sys
 import unittest
 from unittest.mock import patch, MagicMock
 from dotenv import load_dotenv
+from src.tools.us_stock.tool import USFinancialStatementTool
+from src.graph.nodes.us_financial import USFinancialAnalyzerNode
 
 # Load .env file
 load_dotenv()
 
 # Set path
-import sys
-
 sys.path.append("..")  # Add parent directory
-
-from src.tools.us_stock.tool import USFinancialStatementTool
-from src.graph.nodes.us_financial import USFinancialAnalyzerNode
 
 
 class TestTickerExtraction(unittest.TestCase):


### PR DESCRIPTION
# Pull Request
## 💡 PR 요약
API 활용해서 국내 주식 및 미국 주식 재무제표 정보 가져오기 구현 및 데이터 처리 로직 개선

## 🔍 주요 변경사항
- Korea Investment & Securities API와 Alpha Vantage API 연동 기능 구현
- 국내 주식 재무제표 분석을 위한 `HantooFinancialAnalyzerNode` 구현
- 미국 주식 재무제표 분석을 위한 `USFinancialAnalyzerNode` 구현
- 재무제표 분석 도구(Balance Sheet, Income Statement, Financial Ratios) 구현
- 'None' 문자열 처리 로직 개선하여 재무 데이터 파싱 오류 해결
- 각 기능별 단위 테스트 추가

## 🐛 수정된 버그
- Alpha Vantage API에서 반환된 'None' 문자열을 float로 변환하려다 발생하는 ValueError 해결
- 재무 비율 계산 시 null 값이 포함된 경우 오류 발생하는 문제 수정
- LLM 연동 코드에서 더 이상 지원되지 않는 predict() 대신 invoke() 사용하도록 업데이트

## 🔗 연관된 이슈
주식 정보 분석 기능 추가

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] API 키 보안을 위한 환경변수 설정을 추가했나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?
- [x] API 요청 실패에 대한 예외 처리를 구현했나요?
- [x] 외부 API 데이터 누락 및 이상 값에 대한 안전한 처리를 구현했나요?
- [x] PR이 CI/CD 파이프라인을 통과했나요?

## 🙏 리뷰어 참고사항
- 현재 한투 API 분석 에이전트 노드는 주석 처리하고 미국 주식 노드로 대체했습니다. 필요 시 둘 다 활성화할 수 있습니다.
- API 요청 실패 시 사용자에게 친화적인 오류 메시지를 제공하도록 구현했습니다.
- Alpha Vantage API의 요청 제한(rate limit)을 고려하여 간단한 캐싱 기능을 추가했습니다.
- LangSmith를 활용하여 재무 데이터 처리 파이프라인의 오류를 추적하고 디버깅했습니다.
- 외부 API에서 반환되는 다양한 형태의 null 값('None', 빈 문자열 등)을 안전하게 처리하도록 개선했습니다.

## 📋 추가 컨텍스트
이 PR은 금융 분석 에이전트의 핵심 기능인 재무제표 정보 수집 및 분석 기능을 구현합니다. 사용자는 미국 주식(AAPL, AMZN 등)을 입력하여 해당 기업의 재무상태를 분석할 수 있습니다. LLM을 활용하여 회사 이름만으로도 적절한 종목코드/티커를 추출할 수 있도록 했습니다.

특히 Alpha Vantage API에서 반환하는 불규칙한 데이터('None' 문자열, 누락된 값 등)를 안전하게 처리하도록 데이터 파싱 로직을 개선하여, 다양한 기업 데이터에 대해 안정적으로 분석 결과를 제공할 수 있게 되었습니다.