### PR TITLE
fix: 배포 시, 캐시 제거

### DIFF
--- a/.github/workflows/deployment-prod.yml
+++ b/.github/workflows/deployment-prod.yml
@@ -77,9 +77,15 @@ jobs:
           # GID=$CURRENT_GID
           EOF
       
+      - name: Clean Docker build cache
+        run: |
+          echo "=== Docker 빌드 캐시 정리 ==="
+          docker builder prune -af
+          
       - name: Build and tag Docker images
         run: |
-          docker compose -f docker-compose.prod.yaml build backend-ma
+          # 캐시 없이 빌드 (--no-cache 옵션)
+          docker compose -f docker-compose.prod.yaml build --no-cache backend-ma
       
       - name: Stop running containers
         run: |

--- a/images/backend/Dockerfile
+++ b/images/backend/Dockerfile
@@ -1,28 +1,50 @@
-# Python 3.11 베이스 이미지 사용
-FROM python:3.11-slim
+# Stage 1: 의존성 설치
+FROM python:3.11-slim as builder
 
-# 작업 디렉토리 설정
 WORKDIR /app
 
-# 시스템 패키지 설치
+# 빌드에 필요한 시스템 패키지만 설치
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PYTHONDONTWRITEBYTECODE=1
+# uv 설치
+RUN pip install --no-cache-dir uv
 
-# Poetry 대신 uv 설치
-RUN pip install uv
+# 의존성 파일만 먼저 복사 (캐시 활용)
+COPY pyproject.toml uv.lock ./
 
-# 프로젝트 파일 복사
+# 의존성 설치 (개발 의존성 제외)
+RUN uv sync --no-dev
+
+# Stage 2: 최종 런타임 이미지
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# 런타임에 필요한 최소한의 패키지만 설치
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && rm -rf /var/cache/apt/*
+
+# uv만 설치 (캐시 없이)
+RUN pip install --no-cache-dir uv
+
+# 빌더 스테이지에서 가상환경만 복사
+COPY --from=builder /app/.venv /app/.venv
+
+# 애플리케이션 코드 복사
 COPY . /app
 
-# 의존성 설치
-RUN uv sync
+# 환경 변수 설정
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 
 # 포트 설정
 EXPOSE 8000
 
-# 실행 명령
+# 실행 명령 (uv 사용)
 CMD ["uv", "run", "main.py"]


### PR DESCRIPTION
빌드 캐시가 많이 쌓여있었음.

이미지 빌드 시, 캐시를 안 남기도록 `--no-cache` 옵션을 사용하도록 변경하였고, 빌드 스테이지를 2 스테이지로 구성하여 빌더와 운영 컨테이너를 분리

<img width="461" height="126" alt="image" src="https://github.com/user-attachments/assets/2eef6285-24cc-47e7-bbf9-0d20364dd250" />

fix #137 